### PR TITLE
Downloading instead of keeping a copy of ahab in project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates curl
 
 WORKDIR /tmp/ahab
 
-COPY ahab .
+RUN curl -o ahab -O -L  https://github.com/sonatype-nexus-community/ahab/releases/download/v0.0.7/ahab-linux.amd64-v0.0.7
 
 RUN chmod +x ahab
 


### PR DESCRIPTION
Like it says in the title doing the thing to just download it. I did have to install curl (also could have used wget but also would need installed). Feels like a low barrier of entry to have to do. And maybe it makes sense to uninstall after but that could be based on what the end user really wants to do with the Dockerfile. There is a chance they already have it installed anyways. 

cc @DarthHater 